### PR TITLE
Add options for output scaffolds file prefix, making required soft links

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ Notes:
 * `minimap2` is used for mapping reads in the Tigmint step
 * To change the (`-x`) preset used for mapping, specify `longmap=<mode>`
   * For example, to use the nanopore mapping preset, use `longmap=ont` (default), or for PacBio use `longmap=pb`
+  
+### Running LongStitch in pipelines
+* To change to a particular before running LongStitch, you can use the `-C dir` option with the `longstitch` command
+* All input files must be in the working directory for `longstitch` - these can either be created manually or using the `longstitch make_links` command
+  * This command only requires the parameters `reads_path` and `draft_path` to be set - _full_ paths to the reads file and draft fasta file, respectively
 
 ## License
 LongStitch Copyright (c) 2020 British Columbia Cancer Agency Branch. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Usage: ./longstitch [COMMAND] [OPTION=VALUE]…
 	General options (optional):
 	t			number of threads [8]
 	z			minimum size of contig (bp) to scaffold [1000]
+	out_prefix              if supplied, final scaffolds will be soft-linked to <out_prefix>.scaffolds.fa
 
 	Tigmint options:
 	span			min number of spanning molecules to be considered correctly assembled [auto]

--- a/longstitch
+++ b/longstitch
@@ -115,6 +115,7 @@ help:
 	@echo "	General options (optional):"
 	@echo "	t			number of threads [8]"
 	@echo "	z			minimum size of contig (bp) to scaffold [1000]"
+	@echo "	out_prefix		if supplied, final scaffolds will be soft-linked to <out_prefix>.scaffolds.fa"
 	@echo ""
 	@echo "	Tigmint options:"
 	@echo "	span			min number of spanning molecules to be considered correctly assembled [auto]"

--- a/longstitch
+++ b/longstitch
@@ -52,6 +52,9 @@ D=true
 ref=None
 quast_t=48
 
+# Output prefix for final scaffolds file
+out_prefix=None
+
 # Use pigz or bgzip for parallel compression if available.
 ifneq ($(shell command -v pigz),)
 gzip=pigz -p$t
@@ -171,6 +174,9 @@ $(draft).fa.k$(k_ntLink).w$w.z$z.stitch.abyss-scaffold.fa: $(draft).fa $(long_re
 $(draft).k$(k_ntLink).w$(w).tigmint-ntLink.longstitch-scaffolds.fa: $(draft).cut$(cut).tigmint.fa.k$(k_ntLink).w$w.z$z.stitch.abyss-scaffold.fa 
 	ln -sf $< $@
 	echo "Done LongStitch steps Tigmint-long and ntLink! Scaffolds can be found in: $@"
+ifneq ($(out_prefix), None)
+	ln -sf $< $(out_prefix).scaffolds.fa
+endif
 
 # Run arcs-long
 arcs-with-ntLink: $(draft).fa.k$(k_ntLink).w$w.z$z.stitch.abyss-scaffold_c$c_m$m_cut$(cut)_s$s_r$r_e$e_z$z_l$l_a$a.scaffolds.fa
@@ -196,10 +202,16 @@ arks-with-tigmint-ntLink: $(draft).cut$(cut).tigmint.fa.k$(k_ntLink).w$w.z$z.sti
 $(draft).k$(k_ntLink).w$(w).tigmint-ntLink-arks.longstitch-scaffolds.fa: $(draft).cut$(cut).tigmint.fa.k$(k_ntLink).w$w.z$z.stitch.abyss-scaffold_c$c_m$m_cut$(cut)_k$(k_arks)_r$r_e$e_z$z_l$l_a$a.scaffolds.fa
 	ln -sf $< $@
 	echo "Done LongStitch steps Tigmint-long, ntLink and ARKS-long! Scaffolds can be found in: $@"
+ifneq ($(out_prefix), None)
+	ln -sf $< $(out_prefix).scaffolds.fa
+endif
 
 $(draft).k$(k_ntLink).w$(w).ntLink-arks.longstitch-scaffolds.fa: $(draft).fa.k$(k_ntLink).w$w.z$z.stitch.abyss-scaffold_c$c_m$m_cut$(cut)_k$(k_arks)_r$r_e$e_z$z_l$l_a$a.scaffolds.fa
 	ln -sf $< $@
 	echo "Done LongStitch steps ntLink and ARKS-long! Scaffolds can be found in: $@"
+ifneq ($(out_prefix), None)
+	ln -sf $< $(out_prefix).scaffolds.fa
+endif
 
 %.stitch.abyss-scaffold_c$c_m$m_cut$(cut)_k$(k_arks)_r$r_e$e_z$z_l$l_a$a.scaffolds.fa: %.stitch.abyss-scaffold.fa $(long_reads)
 	$(longstitch_time) arcs-make arks-long draft=$*.stitch.abyss-scaffold reads=$(reads) m=$m cut=$(cut) j=$j k=$(k_arks) l=$l c=$c a=$a D=$D z=$z

--- a/longstitch
+++ b/longstitch
@@ -6,6 +6,10 @@
 # Input files
 draft=draft
 reads=reads
+draft_path=draft_path
+draft_path_base=$(shell basename $(draft_path))
+reads_path=reads_path
+reads_path_base=$(shell basename $(reads_path))
 
 # Find the complete long read file name
 fastq=$(shell test -f $(reads).fq.gz && echo "true")
@@ -87,7 +91,7 @@ bin=$(shell dirname `command -v $(MAKEFILE_LIST)`)
 .PHONY: help run version clean tigmint ntLink tigmint-ntLink ntLink-with-tigmint tigmint-arcs tigmint-arks \
 		arcs-with-tigmint arks-with-tigmint ntLink-arcs ntLink-arks arcs-with-ntLink arks-with-ntLink \
 		tigmint-ntLink-arcs tigmint-ntLink-arks arcs-with-tigmint-ntLink arks-with-tigmint-ntLink \
-		check_ref longstitch_quast
+		check_ref longstitch_quast make_links
 .DELETE_ON_ERROR:
 .SECONDARY:
 
@@ -146,6 +150,21 @@ clean:
 version:
 	@echo "LongStitch v1.0.1"
 	@echo "Written by Lauren Coombe, Janet Li and Theodora Lo"
+
+# Make soft links for files
+make_links: $(draft_path_base) $(reads_path_base)
+
+$(draft_path_base): $(draft_path)
+ifeq ($(draft_path),draft_path)
+	$(error For make_links target, must set draft_path)
+endif
+	ln -s $(draft_path)
+
+$(reads_path_base): $(reads_path)
+ifeq ($(reads_path),reads_path)
+	$(error For make_links target, must set reads_path)
+endif
+	ln -s $(reads_path)
 
 # Run tigmint-long
 run: tigmint-ntLink


### PR DESCRIPTION
* Added `out_prefix` optional parameter - if specified, will soft-link the final scaffolds file to `<out_prefix>.scaffolds.fa`
* Added target `make_links` - given full paths to reads file and assembly file using parameters `reads_path` and `draft_path`, will create soft-links in working directory to the files
  * Can be used prior to running `longstitch run` to create the required soft-links 